### PR TITLE
feat: Add workflow dispatch for automatic PR creation

### DIFF
--- a/.github/workflows/create-tool-pr.yml
+++ b/.github/workflows/create-tool-pr.yml
@@ -1,0 +1,83 @@
+name: Create Tool PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch name'
+        required: true
+      tool_name:
+        description: 'Tool name (org/name)'
+        required: true
+      version:
+        description: 'Tool version'
+        required: true
+      publisher:
+        description: 'Publisher username'
+        required: true
+      repository:
+        description: 'Tool repository URL'
+        required: true
+      issue_number:
+        description: 'Source issue number'
+        required: true
+      security_status:
+        description: 'Security scan status'
+        default: 'pass'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+      
+      - name: Create Pull Request
+        run: |
+          # Determine security status icon
+          if [[ "${{ inputs.security_status }}" == "pass" ]]; then
+            SECURITY_ICON="✅"
+          else
+            SECURITY_ICON="⚠️"
+          fi
+          
+          # Create PR body
+          cat > pr-body.md << EOF
+          ## Automated Tool Integration
+          
+          This PR was automatically generated from issue #${{ inputs.issue_number }}.
+          
+          ### Tool Information
+          - **Name**: ${{ inputs.tool_name }}
+          - **Version**: ${{ inputs.version }}
+          - **Publisher**: @${{ inputs.publisher }}
+          - **Repository**: ${{ inputs.repository }}
+          
+          ### Pipeline Status
+          - ✅ Manifest parsed successfully
+          - ✅ Repository cloned
+          - ✅ Tool built successfully
+          - ✅ Format validated
+          - ${SECURITY_ICON} Security scan
+          
+          Closes #${{ inputs.issue_number }}
+          EOF
+          
+          # Create PR
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${{ inputs.branch }}" \
+            --title "🤖 Add tool: ${{ inputs.tool_name }}@${{ inputs.version }}" \
+            --body-file pr-body.md \
+            --label "tool-submission" \
+            --label "automated")
+          
+          echo "Created PR: $PR_URL"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/tool-submission.yml
+++ b/.github/workflows/tool-submission.yml
@@ -450,71 +450,37 @@ jobs:
           
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
       
-      # Phase 9: Create Pull Request  
-      - name: Create Pull Request
+      # Phase 9: Trigger PR Creation Workflow
+      - name: Trigger PR Creation
         if: success()
         id: create-pr
-        run: |
-          echo "🔄 Creating pull request..."
-          
-          # Determine security status icon
-          if [[ "${{ steps.security.outputs.security_status }}" == "pass" ]]; then
-            SECURITY_ICON="✅"
-          else
-            SECURITY_ICON="⚠️"
-          fi
-          
-          # Create PR body using heredoc
-          cat > pr-body.md << EOF
-          ## Automated Tool Integration
-          
-          This PR was automatically generated from issue #${{ github.event.issue.number }}.
-          
-          ### Tool Information
-          - **Name**: ${{ steps.parse-issue.outputs.organization }}/${{ steps.parse-issue.outputs.tool_name }}
-          - **Version**: ${{ steps.clone-tool.outputs.version }}
-          - **Publisher**: @${{ steps.parse-issue.outputs.publisher }}
-          - **Repository**: ${{ steps.parse-issue.outputs.repo_url }}
-          
-          ### Pipeline Status
-          - ✅ Manifest parsed successfully
-          - ✅ Repository cloned
-          - ✅ Tool built successfully
-          - ✅ Format validated
-          - ${SECURITY_ICON} Security scan
-          
-          Closes #${{ github.event.issue.number }}
-          EOF
-          
-          # Create PR using GitHub CLI
-          # Note: When triggered by issues, we need to handle PR creation differently
-          # Try to create PR, but don't fail if it doesn't work due to permissions
-          if PR_URL=$(gh pr create \
-            --base main \
-            --head "${{ steps.integration.outputs.branch }}" \
-            --title "🤖 Add tool: ${{ steps.parse-issue.outputs.organization }}/${{ steps.parse-issue.outputs.tool_name }}@${{ steps.clone-tool.outputs.version }}" \
-            --body-file pr-body.md \
-            --label "tool-submission" \
-            --label "automated" 2>&1); then
-            
-            # Extract PR number from URL
-            PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-            echo "pull-request-number=$PR_NUMBER" >> $GITHUB_OUTPUT
-            echo "pull-request-url=$PR_URL" >> $GITHUB_OUTPUT
-            echo "✅ Pull request created successfully"
-          else
-            # If PR creation fails, just note the branch
-            echo "⚠️ Could not create PR automatically (permissions issue)"
-            echo "Branch created: ${{ steps.integration.outputs.branch }}"
-            echo "A maintainer will need to create the PR manually"
-            echo "pull-request-number=" >> $GITHUB_OUTPUT
-            echo "pull-request-url=" >> $GITHUB_OUTPUT
-          fi
-          
-          # Clean up
-          rm -f pr-body.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              // Trigger the PR creation workflow
+              const result = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'create-tool-pr.yml',
+                ref: 'main',
+                inputs: {
+                  branch: '${{ steps.integration.outputs.branch }}',
+                  tool_name: '${{ steps.parse-issue.outputs.organization }}/${{ steps.parse-issue.outputs.tool_name }}',
+                  version: '${{ steps.clone-tool.outputs.version }}',
+                  publisher: '${{ steps.parse-issue.outputs.publisher }}',
+                  repository: '${{ steps.parse-issue.outputs.repo_url }}',
+                  issue_number: '${{ github.event.issue.number }}',
+                  security_status: '${{ steps.security.outputs.security_status }}'
+                }
+              });
+              
+              console.log('✅ PR creation workflow triggered successfully');
+              core.setOutput('workflow_triggered', 'true');
+            } catch (error) {
+              console.log('⚠️ Could not trigger PR workflow:', error.message);
+              core.setOutput('workflow_triggered', 'false');
+            }
       
       # Phase 10: Post Results
       - name: Post Results Comment
@@ -551,13 +517,13 @@ jobs:
               comment += `### 🎉 Next Steps\n\n`;
               comment += `Your tool has been successfully built and integrated! `;
               
-              const prNumber = '${{ steps.create-pr.outputs.pull-request-number }}';
-              if (prNumber) {
-                comment += `A pull request has been created for review.\n\n`;
-                comment += `**Pull Request**: #${prNumber}\n`;
+              const workflowTriggered = '${{ steps.create-pr.outputs.workflow_triggered }}' === 'true';
+              if (workflowTriggered) {
+                comment += `A pull request workflow has been triggered.\n\n`;
+                comment += `> ℹ️ **Note**: The PR will be created in a separate workflow. Check back in a moment for the PR link.\n\n`;
               } else {
                 comment += `The integration branch has been created.\n\n`;
-                comment += `> ⚠️ **Note**: The PR could not be created automatically due to GitHub permissions. A maintainer will create the PR manually.\n\n`;
+                comment += `> ⚠️ **Note**: The PR workflow could not be triggered automatically. A maintainer will create the PR manually.\n\n`;
               }
               
               comment += `**Branch**: \`${{ steps.integration.outputs.branch }}\`\n\n`;


### PR DESCRIPTION
## Problem
The tool submission workflow cannot create pull requests when triggered by issues because the default GITHUB_TOKEN lacks the necessary permissions for issue-triggered workflows.

## Solution
This PR implements a two-step workflow approach:

1. **Main workflow** (`tool-submission.yml`):
   - Creates the integration branch with tool files
   - Triggers a separate workflow via `workflow_dispatch`
   - Updates the issue with status

2. **PR creation workflow** (`create-tool-pr.yml`):
   - Receives parameters from the main workflow
   - Creates the PR with proper permissions
   - No additional secrets required

## Why This Works
- `workflow_dispatch` events have different permission scopes than issue-triggered events
- The separate workflow runs in a context where PR creation is allowed
- Maintains security without exposing PATs or requiring GitHub Apps

## Changes
- Added new `create-tool-pr.yml` workflow for PR creation
- Updated main workflow to trigger PR creation via workflow_dispatch
- Updated status messages to reflect async PR creation

## Testing
Once merged, we can test by:
1. Deleting the existing elevenlabs branch
2. Creating a new tool submission issue
3. Verifying that the PR is created automatically

This approach ensures smooth tool submissions while maintaining security best practices.