### PR TITLE
fix: Use BOT_TOKEN for PR creation

### DIFF
--- a/.github/workflows/create-tool-pr.yml
+++ b/.github/workflows/create-tool-pr.yml
@@ -80,4 +80,4 @@ jobs:
           
           echo "Created PR: $PR_URL"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
This PR fixes the PR creation workflow by using the BOT_TOKEN secret instead of the default GitHub token.

## Changes
- Updated create-tool-pr.yml to use `${{ secrets.BOT_TOKEN }}` instead of `${{ github.token }}`
- The BOT_TOKEN has been added as a repository secret with proper permissions

## Why This Works
The default GITHUB_TOKEN has restricted permissions due to organization settings. Using a Personal Access Token stored as BOT_TOKEN bypasses these restrictions and allows PR creation.

This is the final piece needed to make the tool submission pipeline fully automated.