### PR TITLE
feat: add npm dependency support to tool submission pipeline

### DIFF
--- a/.github/workflows/tool-submission.yml
+++ b/.github/workflows/tool-submission.yml
@@ -207,6 +207,17 @@ jobs:
             
             console.log('Building from:', entryPoint);
             
+            // Get external dependencies from package.json if it exists
+            let externalDeps = [];
+            const packageJsonPath = path.join(toolDir, 'package.json');
+            if (fs.existsSync(packageJsonPath)) {
+              const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+              const deps = packageJson.dependencies || {};
+              const peerDeps = packageJson.peerDependencies || {};
+              externalDeps = [...Object.keys(deps), ...Object.keys(peerDeps)];
+              console.log('Found dependencies to mark as external:', externalDeps);
+            }
+            
             // Bundle the tool
             await esbuild.build({
               entryPoints: [entryPoint],
@@ -216,9 +227,7 @@ jobs:
               target: 'node16',
               outfile: path.join(outputDir, 'index.js'),
               external: [
-                'react',
-                'ink',
-                '@ziggler/clanker',
+                // Core Node.js modules
                 'child_process',
                 'fs',
                 'path',
@@ -226,7 +235,19 @@ jobs:
                 'util',
                 'stream',
                 'events',
-                'crypto'
+                'crypto',
+                'http',
+                'https',
+                'url',
+                'querystring',
+                'buffer',
+                'process',
+                // Clanker and common UI dependencies
+                '@ziggler/clanker',
+                'react',
+                'ink',
+                // Tool-specific dependencies from package.json
+                ...externalDeps
               ],
               // Avoid top-level await issues
               supported: {
@@ -248,6 +269,14 @@ jobs:
         id: build
         run: |
           echo "🔨 Building tool..."
+          
+          # Check if tool has dependencies and install them
+          if [[ -f "tool-repo/package.json" ]]; then
+            echo "📦 Installing tool dependencies..."
+            cd tool-repo
+            npm install --production
+            cd ..
+          fi
           
           # Create output directory
           mkdir -p build-output


### PR DESCRIPTION
## Description

This PR adds support for tools with npm dependencies in the automated tool submission pipeline. Previously, tools that required npm packages would fail during the build process because dependencies weren't installed.

## Changes

1. **Install npm dependencies before building**: If a tool has a `package.json` file, the workflow now runs `npm install --production` before attempting to build
2. **Dynamic external dependencies**: The build script now reads the tool's `package.json` to automatically mark all dependencies and peerDependencies as external in esbuild
3. **Extended Node.js module list**: Added common Node.js core modules to the external list

## Problem Solved

Tools like `@ziggle-dev/voice-input` (issue #118) were failing with errors like:
```
✘ [ERROR] Could not resolve "node-record-lpcm16"
✘ [ERROR] Could not resolve "form-data"
✘ [ERROR] Could not resolve "node-fetch"
```

This was happening because:
1. The dependencies weren't being installed before the build
2. The dependencies weren't marked as external in esbuild

## Testing

This fix has been tested with the `@ziggle-dev/voice-input` tool submission which requires three npm dependencies:
- node-record-lpcm16
- form-data
- node-fetch

## Impact

- ✅ Enables tools with npm dependencies to be submitted successfully
- ✅ Maintains backward compatibility with tools that don't have dependencies
- ✅ Automatically handles any npm package as external, not just a hardcoded list

## Related Issues

Fixes the build failure in #118