### PR TITLE
fix: copy node_modules for validation step

### DIFF
--- a/.github/workflows/tool-submission.yml
+++ b/.github/workflows/tool-submission.yml
@@ -303,6 +303,12 @@ jobs:
           # Copy built file to build-temp for validation with dependencies
           cp build-output/index.js build-temp/
           
+          # If tool has dependencies, copy node_modules to build-temp for validation
+          if [[ -d "tool-repo/node_modules" ]]; then
+            echo "📦 Copying dependencies for validation..."
+            cp -r tool-repo/node_modules build-temp/
+          fi
+          
           # Create validation script in build-temp
           cat > build-temp/validate-tool.mjs << 'EOF'
           import fs from 'fs';


### PR DESCRIPTION
## Quick Fix

The validation step needs access to npm dependencies to validate tools that import them.

## Problem
Tools with npm dependencies were failing validation with:
```
❌ Validation failed: Cannot find package 'node-record-lpcm16' imported from /home/runner/work/rachet/rachet/build-temp/index.js
```

## Solution
Copy the node_modules directory from tool-repo to build-temp before running validation.

## Testing
This will allow the voice-input tool (#118) to pass validation.

Related to #118