### PR TITLE
feat: include package.json with tools that have dependencies

### DIFF
--- a/.github/workflows/tool-submission.yml
+++ b/.github/workflows/tool-submission.yml
@@ -292,6 +292,29 @@ jobs:
           
           echo "✅ Build successful"
           ls -la build-output/
+          
+          # Create package.json for the tool if it has dependencies
+          if [[ -f "tool-repo/package.json" ]]; then
+            echo "📦 Creating package.json for tool dependencies..."
+            
+            # Extract dependencies from the original package.json
+            DEPS=$(cat tool-repo/package.json | jq -r '.dependencies // {}')
+            PEER_DEPS=$(cat tool-repo/package.json | jq -r '.peerDependencies // {}')
+            
+            # Create a minimal package.json for the tool
+            cat > build-output/package.json << EOF
+          {
+            "name": "${{ steps.parse-issue.outputs.tool_name }}",
+            "version": "${{ steps.clone-tool.outputs.version }}",
+            "description": "${{ steps.parse-issue.outputs.description }}",
+            "main": "index.js",
+            "dependencies": $DEPS,
+            "peerDependencies": $PEER_DEPS
+          }
+          EOF
+            
+            echo "Created package.json with dependencies"
+          fi
       
       # Phase 5: Validate Tool Format
       - name: Validate Tool Format


### PR DESCRIPTION
## Description

This PR updates the tool submission workflow to include a package.json file with tools that have npm dependencies.

## Problem
Tools with npm dependencies (like voice-input) were failing at runtime because their dependencies weren't available when Clanker tried to load them.

## Solution
When a tool has dependencies, the workflow now creates a minimal package.json that includes:
- Tool name and version
- Dependencies from the original package.json
- Peer dependencies if any

This package.json is included in the tool distribution, allowing Clanker to install the dependencies when the tool is first loaded.

## Testing
This will enable the voice-input tool to work correctly once Clanker is updated to install dependencies at runtime.

## Related Issues
- Fixes runtime issues for #118 (voice-input tool)

## Next Steps
After this is merged, Clanker will be updated to:
1. Check for package.json in tool directories
2. Install dependencies when loading a tool for the first time
3. Cache the installed dependencies for subsequent loads