### PR TITLE
fix: preserve package.json in tool directories

### DIFF
--- a/.github/workflows/tool-submission.yml
+++ b/.github/workflows/tool-submission.yml
@@ -498,8 +498,10 @@ jobs:
           EOF
           fi
           
-          # Clean up temporary files before committing
-          rm -rf build-temp build-output node_modules package*.json tool-repo audit-report.json pr-body.md 2>/dev/null || true
+          # Clean up temporary files before committing (but keep tool artifacts)
+          rm -rf build-temp build-output node_modules tool-repo audit-report.json pr-body.md 2>/dev/null || true
+          # Clean up root package files but not in tools directory
+          rm -f package.json package-lock.json 2>/dev/null || true
           
           # Commit and push only the tools directory
           git add tools/


### PR DESCRIPTION
## Quick Fix

The cleanup step was incorrectly removing package.json files from tool directories.

## Problem
When including package.json with tools (added in #122), the cleanup step was removing them with the glob pattern `package*.json`.

## Solution
- Keep the `rm -rf` for directories
- Use `rm -f` for specific root-level package files
- This preserves package.json files in the tools/ directory structure

## Testing
This will allow voice-input tool (#118) to include its package.json for dependency installation.

## Impact
Tools with npm dependencies will now correctly include their package.json files in the distribution.