### PR TITLE
fix: ensure package.json is copied to tool directory

### DIFF
--- a/.github/workflows/tool-submission.yml
+++ b/.github/workflows/tool-submission.yml
@@ -464,8 +464,8 @@ jobs:
           TOOL_DIR="tools/${{ steps.parse-issue.outputs.organization }}/${{ steps.parse-issue.outputs.tool_name }}/${{ steps.clone-tool.outputs.version }}"
           mkdir -p "$TOOL_DIR"
           
-          # Copy build artifacts
-          cp build-output/* "$TOOL_DIR/"
+          # Copy all build artifacts including package.json
+          cp -r build-output/. "$TOOL_DIR/"
           
           # Create or update tool metadata
           METADATA_FILE="tools/${{ steps.parse-issue.outputs.organization }}/${{ steps.parse-issue.outputs.tool_name }}/metadata.json"


### PR DESCRIPTION
## Summary
Fixed an issue where package.json was not being copied to the tool directory during the submission workflow.

## Problem
The workflow was creating a package.json file for tools with dependencies, but it wasn't being copied to the final tool directory. This caused tools with npm dependencies to fail at runtime.

## Solution
Changed the copy command from `cp build-output/* "$TOOL_DIR/"` to `cp -r build-output/. "$TOOL_DIR/"` to ensure all files including package.json are copied.

## Test plan
This fix will be validated when the next tool with dependencies is submitted through the workflow.